### PR TITLE
Reduce duplicate calls to play(), possible fix for #233

### DIFF
--- a/engine/src/hikari/client/audio/AudioService.cpp
+++ b/engine/src/hikari/client/audio/AudioService.cpp
@@ -56,10 +56,6 @@ namespace hikari {
     void AudioService::playMusic(const std::string & name) {
         if(library->isEnabled()) {
             const auto stream = library->playMusic(name, getMusicVolume());
-
-            if(stream) {
-                stream->play();
-            }
         }
     }
 
@@ -82,10 +78,6 @@ namespace hikari {
     void AudioService::playSample(const std::string & name) {
         if(library->isEnabled()) {
             const auto stream = library->playSample(name, getSampleVolume());
-
-            if(stream) {
-                stream->play();
-            }
         }
     }
 


### PR DESCRIPTION
The error from issue #233 seems to indicate that something inside of OpenAL is not able to dequeue or queue a buffer. It turns out that we've actually been having all music and sounds play TWICE every time they're requested -- probably due to a bad pass at cleaning up or moving code. This removes the duplicate calls to `play` for each of the audio and music streams.