### PR TITLE
Remove erroneous & from SpriteAnimator API

### DIFF
--- a/engine/include/hikari/core/game/SpriteAnimator.hpp
+++ b/engine/include/hikari/core/game/SpriteAnimator.hpp
@@ -21,8 +21,8 @@ namespace hikari {
     public:
         SpriteAnimator(sf::Sprite &sprite); 
         virtual ~SpriteAnimator();
-        void setInvertXOffset(const bool& flip);
-        void setInvertYOffset(const bool& flip);
+        void setInvertXOffset(const bool flip);
+        void setInvertYOffset(const bool flip);
         virtual void update(float delta);
     };
 

--- a/engine/src/hikari/core/game/SpriteAnimator.cpp
+++ b/engine/src/hikari/core/game/SpriteAnimator.cpp
@@ -17,11 +17,11 @@ namespace hikari {
 
     }
 
-    void SpriteAnimator::setInvertXOffset(const bool& flip) {
+    void SpriteAnimator::setInvertXOffset(const bool flip) {
         this->invertXOffset = flip;
     }
 
-    void SpriteAnimator::setInvertYOffset(const bool& flip) {
+    void SpriteAnimator::setInvertYOffset(const bool flip) {
         this->invertYOffset = flip;
     }
 


### PR DESCRIPTION
Don't need to pass booleans by reference LOL.