### PR TITLE
Make Compatible with Modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.21)
 
 project(hikari)
 


### PR DESCRIPTION
Simply updates the minimum required CMake version to 3.21.